### PR TITLE
Adding expiration support, replaced jwt-simple with node-jsonwebtoken, 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var Boom = require('boom');
 var Hoek = require('hoek');
-var jwt  = require('jwt-simple');
+var jwt  = require('jsonwebtoken');
 
 function register (plugin, options, next) {
   plugin.auth.scheme('bearer-access-token', function (server, options) {
@@ -36,7 +36,17 @@ function register (plugin, options, next) {
         }
 
         try {
-          decoded = jwt.decode(token, settings.secret);
+          jwt.verify(token, settings.secret, function (err, data) {
+            if ( err ) {
+              if ( err.name === 'TokenExpiredError' ) {
+                return reply(Boom.unauthorized('Bearer Token is expired', 'Bearer'));
+              } else {
+                return reply(Boom.badRequest('Unable to decode Bearer Token', 'Bearer'));
+              }
+            } else {
+              decoded = data;
+            }
+          });
         } catch (err) {
           return reply(Boom.badRequest('Unable to decode Bearer Token', 'Bearer'));
         }

--- a/index.js
+++ b/index.js
@@ -35,21 +35,27 @@ function register (plugin, options, next) {
           return reply(Boom.unauthorized('Must include a Bearer Token', 'Bearer'));
         }
 
-        try {
-          jwt.verify(token, settings.secret, function (err, data) {
-            if ( err ) {
-              if ( err.name === 'TokenExpiredError' ) {
-                return reply(Boom.unauthorized('Bearer Token is expired', 'Bearer'));
-              } else {
-                return reply(Boom.badRequest('Unable to decode Bearer Token', 'Bearer'));
-              }
+        // Verify the token
+        jwt.verify(token, settings.secret, function (err, data) {
+
+          if ( err ) {
+            if ( err.name === 'TokenExpiredError' ) {
+
+              // Return 401 if the token is expired
+              return reply(Boom.unauthorized('Bearer Token is expired', 'Bearer'));
             } else {
-              decoded = data;
+
+              // Return 400 otherwise
+              return reply(Boom.badRequest('Unable to decode Bearer Token', 'Bearer'));
             }
-          });
-        } catch (err) {
-          return reply(Boom.badRequest('Unable to decode Bearer Token', 'Bearer'));
-        }
+
+          } else {
+
+            // Set the decoded token
+            decoded = data;
+          }
+
+        });
 
         settings.validateFunc(decoded, request, function (err, isValid, credentials) {
           if (err) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "boom": "^2.4.2",
     "hoek": "^2.3.0",
+    "jsonwebtoken": "^1.1.2",
     "jwt-simple": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "boom": "^2.4.2",
     "hoek": "^2.3.0",
-    "jsonwebtoken": "^1.1.2",
-    "jwt-simple": "^0.2.0"
+    "jsonwebtoken": "^1.1.2"
   },
   "devDependencies": {
     "hapi": "^6.2.2",


### PR DESCRIPTION
I've changed the package's JWT library from [jwt-simple](https://github.com/hokaccha/node-jwt-simple) to [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken). In doing so, I was able to add an error check on expired tokens, so a client can handle the expiration properly, i.e. request a new token.

My reasoning for the change is jwt-simple currently does not implement token expiration, [nor is it planned to be added in the near future](https://github.com/hokaccha/node-jwt-simple/issues/8). node-jsonwebtoken is also a much more robust library, and is being actively maintained.

 This change is not breaking.
